### PR TITLE
hotfixed on typeDefs

### DIFF
--- a/server/schemas/typedefs.js
+++ b/server/schemas/typedefs.js
@@ -1,7 +1,5 @@
 const { gql } = require('apollo-server-express');
 
-module.exports = typeDefs;
-
 const typeDefs = gql`
   type Admin {
     _id: ID


### PR DESCRIPTION
Please review for hotfixed:
1. Rename typedefs to typeDefs to match with index.js import
2. Removed the extra line of export module typeDefs.