### PR TITLE
fixed typo on name file

### DIFF
--- a/server/schemas/typedefs.js
+++ b/server/schemas/typedefs.js
@@ -2,13 +2,13 @@ const { gql } = require('apollo-server-express');
 
 const typeDefs = gql`
   type Admin {
-    _id: ID
-    Adminname: String
-    email: String
+    _id: ID!
+    username: String!
+    email: String!
   }
   type Auth {
     token: ID!
-    admin: Admin
+    user: Admin
   }
   type Query {
     me: Admin


### PR DESCRIPTION
Don't know why the last hotfixed did not change the file name from typedefs.js to typeDefs.js. Hope this one will do the job.