### PR TITLE
Fix to routes not working during a refresh

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -49,8 +49,12 @@ if (process.env.NODE_ENV === "production") {
 }
 
 /* This is setting '/' as the home path */
-app.get("/", (req, res) => {
-  res.sendFile(path.join(__dirname, "../client/build/index.html"));
+app.get("/*", (req, res) => {
+  res.sendFile(path.join(__dirname, "../client/build/index.html"), function (err) {
+    if (err) {
+      res.status(500).send(err);
+    }
+  });
 });
 
 


### PR DESCRIPTION
When going to a route, for example, https://daisy-test-server.herokuapp.com/login, and refreshing the page, it will display "Cannot GET /login" 

or when going directly to "https://daisy-test-server.herokuapp.com/login" the URL will show "Cannot get /login"

Fix to it was using 

```
app.get("/*", (req, res) => {
  res.sendFile(path.join(__dirname, "../client/build/index.html"), function (err) {
    if (err) {
      res.status(500).send(err);
    }
  });
}); 
```